### PR TITLE
Patch the setting loader

### DIFF
--- a/reporter/util/settings.js
+++ b/reporter/util/settings.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 class Settings {
   constructor() {
     const dir = fs.readdirSync("./");
-    dir.includes("settings.json") ? (this.settings = require("../settings.json")) : this.createNewSettings();
+    dir.includes("settings.json") ? (this.settings = require(`${process.cwd()}/settings.json`)) : this.createNewSettings();
   }
 
   createNewSettings() {


### PR DESCRIPTION
Patched the setting loader so pkg properly compiles. It will try to bake in settings.json if you don't use process.cwd(), per their [documentation](https://www.npmjs.com/package/pkg#snapshot-filesystem)